### PR TITLE
Fix running the app in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ pip install -e .
 ```
 
 ```bash
-streamlit run app/main.py
+cd app
+streamlit run main.py
 ```
 
 


### PR DESCRIPTION
If the app is run with the original provided instructions `logo.png` will not be found as well as other paths. main.py has to be run from the `app` folder.

Other solution would be to change all the paths so that the app can be run from the parent directory using `streamlit run app/main.py`.